### PR TITLE
Setup Posts endpoints and middleware for mp3/mpeg storage to SQL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,10 @@
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-gcp-starter-secretmanager</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-gcp-starter-storage</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/appengine/app.yaml
+++ b/src/main/appengine/app.yaml
@@ -1,5 +1,5 @@
 runtime: java11
-instance_class: F4
+instance_class: F2
 automatic_scaling:
   min_instances: 1
   max_instances: 4

--- a/src/main/java/com/gcp/springboot/jamsession/api/post/Post.java
+++ b/src/main/java/com/gcp/springboot/jamsession/api/post/Post.java
@@ -1,0 +1,119 @@
+package com.gcp.springboot.jamsession.api.post;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.gcp.springboot.jamsession.api.user.User;
+
+import javax.persistence.*;
+
+@Entity
+@Table(name = "Posts")
+public class Post {
+    // Class Definition
+    @Id @GeneratedValue(strategy=GenerationType.IDENTITY)
+    @Column(name = "post_id")
+    private Long id;
+
+    @Column(name = "title")
+    private String title;
+
+    @Column(name = "description")
+    private String description;
+
+    // TODO: use proper type datetime for sorting
+    @Column(name = "time_creation")
+    private String datetime;
+
+    @JsonIgnore
+    @Column(name = "data")
+    @Lob
+    private byte[] data;
+
+    @JsonIgnore
+    @Column(name = "filetype")
+    private String type;
+
+    @Column(name = "media_link")
+    private String link;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    public Post() {}
+
+    // Getters and Setters
+    public long getPostId() {
+        return id;
+    }
+
+    public void setPostId(long id) {
+        this.id = id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getDatetime() {
+        return datetime;
+    }
+
+    public void setDatetime(String datetime) {
+        this.datetime = datetime;
+    }
+
+    public byte[] getData() {
+        return data;
+    }
+
+    public void setData(byte[] data) {
+        this.data = data;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getMediaLink() {
+        return link;
+    }
+
+    public void setMediaLink(String link) {
+        this.link = link;
+    }
+
+    public void setUser(User user) {
+        this.user = user;
+    }
+
+    public Long getUserId() {
+        return user.getUserId();
+    }
+
+    // Constructors
+    public Post(String title, String description, String datetime, byte[] data, String type, User user) {
+        super();
+        this.title = title;
+        this.description = description;
+        this.datetime = datetime;
+        this.data = data;
+        this.type = type;
+        this.user = user;
+    }
+}

--- a/src/main/java/com/gcp/springboot/jamsession/api/post/PostController.java
+++ b/src/main/java/com/gcp/springboot/jamsession/api/post/PostController.java
@@ -1,0 +1,57 @@
+package com.gcp.springboot.jamsession.api.post;
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+@CrossOrigin
+@Controller
+public class PostController {
+
+@Autowired
+    private PostService postService;
+
+    @PostMapping(value = "/posts/")
+    @ResponseBody
+    public ResponseEntity<Post> addPost(@RequestParam(required = true, value="title") String title,
+            @RequestParam(required = true, value="description") String description,
+            @RequestParam(required = true, value="datetime") String datetime,
+            @RequestParam(required = true, value="file") MultipartFile file,
+            @RequestParam(required = true, value="user_id") Long userId) {
+
+        try {
+            Post post = postService.createPost(title, description, datetime, file, userId);
+            return new ResponseEntity<>(post, HttpStatus.CREATED);
+        }
+        catch (Exception e) {
+            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+        }
+    }
+
+    @GetMapping("/posts/{post_id}/media/")
+    public ResponseEntity<byte[]> getPost(@PathVariable("post_id") Long postId) {
+        Optional<Post> post = postService.getPost(postId);
+
+        if(post.isEmpty()) {
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        }
+
+        return ResponseEntity.ok()
+            .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + post.get().getPostId() + ".mpeg\"")
+            .body(post.get().getData());
+    }
+}

--- a/src/main/java/com/gcp/springboot/jamsession/api/post/PostRepository.java
+++ b/src/main/java/com/gcp/springboot/jamsession/api/post/PostRepository.java
@@ -1,0 +1,8 @@
+package com.gcp.springboot.jamsession.api.post;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.web.bind.annotation.CrossOrigin;
+
+@CrossOrigin
+public interface PostRepository extends JpaRepository<Post, Long> {
+}

--- a/src/main/java/com/gcp/springboot/jamsession/api/post/PostService.java
+++ b/src/main/java/com/gcp/springboot/jamsession/api/post/PostService.java
@@ -1,0 +1,48 @@
+package com.gcp.springboot.jamsession.api.post;
+
+import org.springframework.stereotype.Service;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import com.gcp.springboot.jamsession.api.user.User;
+import com.gcp.springboot.jamsession.api.user.UserRepository;
+
+import java.io.IOException;
+import java.util.Optional;
+
+@Service
+public class PostService {
+
+    @Autowired
+    private PostRepository postRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    public Post createPost(String title, String description, String datetime, MultipartFile file, Long userId) 
+            throws IOException {
+        
+        Optional<User> user = userRepository.findById(userId);
+        
+        if(user.isEmpty()) {
+            throw new IllegalArgumentException();
+        }
+
+        Post post = new Post(title, description, datetime, file.getBytes(), file.getContentType(), user.get());
+        String link = ServletUriComponentsBuilder.fromCurrentContextPath()
+            .path("/posts/")
+            .path(userId.toString())
+            .path("/media/")
+            .toUriString();
+        post.setMediaLink(link);
+        
+        postRepository.save(post);
+        return post;
+    }
+
+    public Optional<Post> getPost(Long id) {
+        Optional<Post> post = postRepository.findById(id);
+        return post;
+    }
+}

--- a/src/main/java/com/gcp/springboot/jamsession/api/user/User.java
+++ b/src/main/java/com/gcp/springboot/jamsession/api/user/User.java
@@ -5,6 +5,7 @@ import javax.persistence.*;
 import com.gcp.springboot.jamsession.api.genre.Genre;
 import com.gcp.springboot.jamsession.api.instrument.Instrument;
 import com.gcp.springboot.jamsession.api.login.Login;
+import com.gcp.springboot.jamsession.api.post.Post;
 import com.gcp.springboot.jamsession.api.session.Session;
 
 import java.sql.Date;
@@ -60,6 +61,9 @@ public class User {
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private Set<Session> sessions = new HashSet<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<Post> posts = new HashSet<>();
 
     public User() {}
 
@@ -168,6 +172,10 @@ public class User {
  
     public Set<Session> getSessions() {
         return sessions;
+    }
+
+    public Set<Post> getPosts() {
+        return posts;
     }
 
     public Login getLogin() {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -31,3 +31,6 @@ spring.main.allow-bean-definition-overriding=true
 # APPLICATION DEFAULT CREDENTIALS (uncomment for local development)
 #spring.cloud.gcp.credentials.location=file:src/main/resources/key.json
 spring.profiles.active=mysql
+
+spring.servlet.multipart.max-file-size=20MB
+spring.servlet.multipart.max-request-size=20MB


### PR DESCRIPTION
Working on documentation -

/posts/ endpoints implemented and tests added to Postman. Main thing to note is that the CREATE operation uses form-data for the request to pass an MP3/MPEG file - a custom controller breaks this down into a byte array and stores in the SQL database as a LOB. The API never exposes the raw bytes, it manually unpacks on CREATE and then provides an endpoint for getting the file as a link.

<img width="216" alt="image" src="https://user-images.githubusercontent.com/28081457/221698284-236385cf-65a7-4ffa-b46e-033875e740eb.png">
<img width="569" alt="image" src="https://user-images.githubusercontent.com/28081457/221698342-796ccb6b-faad-4bb0-9d48-4579fdf8bec8.png">
