### PR TITLE
Introduces endpoint to check user and login

### DIFF
--- a/src/main/java/com/gcp/springboot/jamsession/api/user/User.java
+++ b/src/main/java/com/gcp/springboot/jamsession/api/user/User.java
@@ -2,6 +2,9 @@ package com.gcp.springboot.jamsession.api.user;
 
 import javax.persistence.*;
 
+import org.hibernate.annotations.Fetch;
+import org.hibernate.annotations.FetchMode;
+
 import com.gcp.springboot.jamsession.api.comment.Comment;
 import com.gcp.springboot.jamsession.api.genre.Genre;
 import com.gcp.springboot.jamsession.api.instrument.Instrument;

--- a/src/main/java/com/gcp/springboot/jamsession/api/user/UserController.java
+++ b/src/main/java/com/gcp/springboot/jamsession/api/user/UserController.java
@@ -1,6 +1,44 @@
 package com.gcp.springboot.jamsession.api.user;
-import org.springframework.data.rest.webmvc.RepositoryRestController;
+import java.util.Optional;
 
-@RepositoryRestController
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@CrossOrigin
+@Controller
 public class UserController {
+
+    public static class LoginDto {
+        public String email;
+        public String password;
+    }
+    
+    @Autowired
+    private UserRepository userRepo;
+
+    @PostMapping(value = "/login")
+    public ResponseEntity<Boolean> checkLogin(
+            @RequestBody LoginDto creds) {
+
+        User user = userRepo.findByEmail(creds.email);
+        System.out.println(creds.password);
+        System.out.println(creds.email);
+
+        if(user == null){
+            return new ResponseEntity<>(false, HttpStatus.NOT_FOUND);
+        }
+        else {
+            if(creds.password.equals(user.getLogin().getSaltedPass())) {
+                return new ResponseEntity<>(true, HttpStatus.OK);
+            }
+            else {
+                return new ResponseEntity<>(false, HttpStatus.UNAUTHORIZED);
+            }
+        }
+    }
 }

--- a/src/main/java/com/gcp/springboot/jamsession/api/user/UserRepository.java
+++ b/src/main/java/com/gcp/springboot/jamsession/api/user/UserRepository.java
@@ -2,6 +2,8 @@ package com.gcp.springboot.jamsession.api.user;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.web.bind.annotation.CrossOrigin;
 
 @CrossOrigin
@@ -10,4 +12,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
     public List<User> findByInstrumentsId(Long id);
     public List<User> findByGenresId(Long id);
     public List<User> findByLocationZipcode(Integer zipcode);
+    public User findByEmail(@Param("email") String email);
 }


### PR DESCRIPTION
Noticed frontend has to currently get all users to check login info - this hides the password properly via POST request and check on server side while eliminating needless data processing.

Success: 200 OK, returns a TRUE for email+password check
Email not found: 404 NOT FOUND, returns FALSE for email check
Incorrect password: 401 NOT AUTHORIZED, returns FALSE for email+password check