### PR TITLE
Completely opens up CORS configuration to all origins/headers/methods

### DIFF
--- a/src/main/java/com/gcp/springboot/jamsession/api/GlobalRepositoryRestConfigurer.java
+++ b/src/main/java/com/gcp/springboot/jamsession/api/GlobalRepositoryRestConfigurer.java
@@ -1,0 +1,18 @@
+package com.gcp.springboot.jamsession.api;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.rest.core.config.RepositoryRestConfiguration;
+import org.springframework.data.rest.webmvc.config.RepositoryRestConfigurerAdapter;
+
+@Configuration 
+public class GlobalRepositoryRestConfigurer extends RepositoryRestConfigurerAdapter {
+
+	@Override
+	public void configureRepositoryRestConfiguration(RepositoryRestConfiguration config) {
+		config.getCorsRegistry()
+				.addMapping("/**")
+				.allowedOrigins("*")
+				.allowedHeaders("*")
+				.allowedMethods("*");
+	}
+}


### PR DESCRIPTION
Not best-practice but we can change the origins to be the frontend website once testing is complete since we're utilizing one host for prod/dev work.