### PR TITLE
Edited /login/ endpoint to return user_id instead of boolean

### DIFF
--- a/src/main/java/com/gcp/springboot/jamsession/api/user/UserController.java
+++ b/src/main/java/com/gcp/springboot/jamsession/api/user/UserController.java
@@ -1,5 +1,4 @@
 package com.gcp.springboot.jamsession.api.user;
-import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -22,22 +21,20 @@ public class UserController {
     private UserRepository userRepo;
 
     @PostMapping(value = "/login")
-    public ResponseEntity<Boolean> checkLogin(
+    public ResponseEntity<Long> checkLogin(
             @RequestBody LoginDto creds) {
 
         User user = userRepo.findByEmail(creds.email);
-        System.out.println(creds.password);
-        System.out.println(creds.email);
 
         if(user == null){
-            return new ResponseEntity<>(false, HttpStatus.NOT_FOUND);
+            return new ResponseEntity<>((long) 0, HttpStatus.NOT_FOUND);
         }
         else {
             if(creds.password.equals(user.getLogin().getSaltedPass())) {
-                return new ResponseEntity<>(true, HttpStatus.OK);
+                return new ResponseEntity<>(user.getUserId(), HttpStatus.OK);
             }
             else {
-                return new ResponseEntity<>(false, HttpStatus.UNAUTHORIZED);
+                return new ResponseEntity<>((long) 0, HttpStatus.UNAUTHORIZED);
             }
         }
     }

--- a/src/main/java/com/gcp/springboot/jamsession/api/user/UserRepository.java
+++ b/src/main/java/com/gcp/springboot/jamsession/api/user/UserRepository.java
@@ -2,7 +2,6 @@ package com.gcp.springboot.jamsession.api.user;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.web.bind.annotation.CrossOrigin;
 


### PR DESCRIPTION
Frontend guys only need user_id on succesful login; returning that prevents needing to make a second query for user's data